### PR TITLE
update install script to hard-reload

### DIFF
--- a/scripts/sw-install.js
+++ b/scripts/sw-install.js
@@ -22,61 +22,72 @@ import {PushHandler} from './components/push-handler';
 
 export function installServiceWorker () {
   if (!('serviceWorker' in navigator)) {
-    console.log('Service Worker not supported - aborting');
+    console.log('Service Worker not supported');
     return;
   }
 
-  var currentVersion = null;
+  let currentVersion = null;
+  let preventReloadLoop = false;
 
-  navigator.serviceWorker.onmessage = function (evt) {
-    if (typeof evt.data.version !== 'undefined') {
-      if (currentVersion === null) {
-        currentVersion = evt.data.version;
-      } else {
-        var newVersion = evt.data.version;
-        var cvParts = currentVersion.split('.');
-        var nvParts = newVersion.split('.');
-
-        if (cvParts[0] === nvParts[0]) {
-          console.log('Service Worker moved from ' +
-                    currentVersion + ' to ' + newVersion);
-        } else {
-          Toast.create('Site updated. Refresh to get the latest!');
-        }
-      }
+  navigator.serviceWorker.onmessage = (evt) => {
+    if (typeof evt.data.version === 'undefined') {
+      return;
     }
-  };
-
-  navigator.serviceWorker.ready.then(function (registration) {
-    if (!('pushManager' in registration)) {
+    if (currentVersion === null) {
+      currentVersion = evt.data.version;  // we didn't have a version, so just set it
       return;
     }
 
+    // The SW tells us its version, so if we're here it's because a new SW has posted it to us.
+    const newVersion = evt.data.version;
+    const cvParts = currentVersion.split('.');
+    const nvParts = newVersion.split('.');
+
+    console.info('Service Worker upgrade from', currentVersion, 'to', newVersion);
+
+    if (cvParts[0] !== nvParts[0]) {
+      // The major version changed. Force a reload.
+      if (!preventReloadLoop) {
+        preventReloadLoop = true;
+        window.location.reload();
+      }
+    } else if (cvParts[1] !== nvParts[1]) {
+      // The minor version changed. Show a toast.
+      Toast.create('Site updated. Refresh to get the latest!');
+    } else if (cvParts[2] !== cvParts[1]) {
+      // If the patch version changed, do nothing.
+    }
+  };
+
+  navigator.serviceWorker.ready.then((registration) => {
+    if (!('pushManager' in registration)) {
+      return;
+    }
     PushHandler.init();
   });
 
-  navigator.serviceWorker.register('/devsummit/sw.js').then(function (registration) {
+  navigator.serviceWorker.register('/devsummit/sw.js').then((registration) => {
     if (registration.active) {
       registration.active.postMessage('version');
     }
 
     // We should also start tracking for any updates to the Service Worker.
-    registration.onupdatefound = function () {
-      console.log('A new version has been found... Installing...');
+    registration.onupdatefound = () => {
+      console.log('A new Service Worker version has been found... Installing...');
 
       // If an update is found the spec says that there is a new Service Worker
       // installing, so we should wait for that to complete then show a
       // notification to the user.
       registration.installing.onstatechange = function () {
         if (this.state === 'installed') {
-          return console.log('App updated');
+          return console.log('Service Worker updated');
         }
-
         if (this.state === 'activated') {
+          // This will cause the version to be posted to onmessage above, which
+          // will reload or show a Toast as appropriate.
           registration.active.postMessage('version');
         }
-
-        console.log('Incoming SW state:', this.state);
+        console.log('Incoming Service Worker state:', this.state);
       };
     };
   });


### PR DESCRIPTION
Make major changes reload the site, and minor changes show a toast.

Previously major showed a toast, and nothing else.

Also adds a few comments and changes `function()` to `() => ... ` where appropriate.